### PR TITLE
Add MongoDB storage backend to docs

### DIFF
--- a/content/docs/best_practices/storage.md
+++ b/content/docs/best_practices/storage.md
@@ -22,3 +22,5 @@ See [redis example](/docs/examples/redis_backend) for details.
 
 
 ### [SQLite3 backend](https://github.com/velebak/colly-sqlite3-storage)
+
+### [MongoDB backend](https://github.com/zolamk/colly-mongo-storage)


### PR DESCRIPTION
This pull request adds a MongoDB storage backend to the docs